### PR TITLE
Dealing with unnecessary console logs  

### DIFF
--- a/cameratransform/camera.py
+++ b/cameratransform/camera.py
@@ -956,7 +956,7 @@ class Camera(ClassWithParameterSet):
         # ensure that the points are provided as an array
         points = np.array(points)
         # get the index which coordinate to force to the given value
-        given = np.array([X, Y, Z])
+        given = np.array([X, Y, Z], dtype=object)
         if X is not None:
             index = 0
         elif Y is not None:

--- a/cameratransform/parameter_set.py
+++ b/cameratransform/parameter_set.py
@@ -279,7 +279,7 @@ class ClassWithParameterSet(object):
         self.parameters.set_fit_parameters(names, p["x"])
         return p
 
-    def metropolis(self, parameter, step=1, iterations=1e5, burn=0.1, disable_bar=False):
+    def metropolis(self, parameter, step=1, iterations=1e5, burn=0.1, disable_bar=False, print_trace=True):
         start = []
         parameter_names = []
         additional_parameter_names = []
@@ -309,7 +309,8 @@ class ClassWithParameterSet(object):
 
         # convert the trace to a pandas dataframe
         trace = pd.DataFrame(trace, columns=list(parameter_names)+list(additional_parameter_names)+["probability"])
-        print(trace)
+        if print_trace:
+            print(trace)
         self.set_trace(trace)
         self.set_to_mean()
         return trace

--- a/cameratransform/parameter_set.py
+++ b/cameratransform/parameter_set.py
@@ -279,7 +279,7 @@ class ClassWithParameterSet(object):
         self.parameters.set_fit_parameters(names, p["x"])
         return p
 
-    def metropolis(self, parameter, step=1, iterations=1e5, burn=0.1):
+    def metropolis(self, parameter, step=1, iterations=1e5, burn=0.1, disable_bar=False):
         start = []
         parameter_names = []
         additional_parameter_names = []
@@ -305,7 +305,7 @@ class ClassWithParameterSet(object):
         if trys >= max_tries:
             raise ValueError("Could not find a starting position with non-zero probability.")
 
-        trace = metropolis(getLogProb, start, step=step, iterations=iterations, burn=burn)
+        trace = metropolis(getLogProb, start, step=step, iterations=iterations, burn=burn, disable_bar=disable_bar)
 
         # convert the trace to a pandas dataframe
         trace = pd.DataFrame(trace, columns=list(parameter_names)+list(additional_parameter_names)+["probability"])

--- a/cameratransform/statistic.py
+++ b/cameratransform/statistic.py
@@ -65,7 +65,7 @@ class normal_bounded(np.ndarray):
         return self.__add__(other)
 
 
-def metropolis(getLogProb, start, step=1, iterations=1e5, burn=0.1, prior_trace=None):
+def metropolis(getLogProb, start, step=1, iterations=1e5, burn=0.1, prior_trace=None, disable_bar=False):
     if burn < 1:
         burn = int(iterations*burn)
     else:
@@ -90,7 +90,7 @@ def metropolis(getLogProb, start, step=1, iterations=1e5, burn=0.1, prior_trace=
     last_pos = start
     last_prob = getLogProb(list(last_pos) + next_prior_trace)
     # iterate to sample
-    with tqdm.trange(int(iterations)) as t:
+    with tqdm.trange(int(iterations), disable=disable_bar) as t:
         for i in t:
             if prior_trace is not None:
                 next_prior_trace = list(prior_trace.loc[np.random.randint(len(prior_trace))])[:-1]


### PR DESCRIPTION
In this pull request, I propose some small changes to cameratransform's current use of logging and one VisibleDeprecationWarning. The changes proposed will not significantly change behaviour for current implementations of cameratransform.

Fixes:
- Added dtype=object to the creation of the "given" array on line 959. Without this, this line throws a numpy VisibleDeprecationWarning. This is because the variables `X, Y, Z` may be of different shapes and types entirely. 

Changes:
- Added an option to disable the tqdm progress bar, this progress bar isn't always needed and may mess with iPython console logs when Metropolis is called multiple times successively. The `disable_bar` parameter defaults to False, meaning that, unless specified, the tqdm loading bar is used.

- Added an option to disable the print of the `trace` object, this pandas table isn't necessary to print for all projects and causes some clutter. The default value for the `print_trace` parameters is True, meaning that, unless specified, the variable `trace` will still be printed.

 